### PR TITLE
Generate our own SSL certificate instead of using the global default one.

### DIFF
--- a/nubis/terraform/inputs.tf
+++ b/nubis/terraform/inputs.tf
@@ -96,10 +96,6 @@ variable "email" {
   default = "gozer@mozilla.com"
 }
 
-variable "https_cert_arn" {
-  description = "ARN of the SSL cert to use for https traffic"
-}
-
 variable "version" {
   description = "Version of nubis-ci to deploy"
 }


### PR DESCRIPTION
Gets rid of https_cert_arn variable too

Fixes #216