### PR TITLE
Explicitely install MarkupSafe==0.23 as it now appears to be a missing dependency somehow

### DIFF
--- a/nubis/puppet/jenkins.pp
+++ b/nubis/puppet/jenkins.pp
@@ -185,6 +185,11 @@ python::pip { 'ansible':
   require => Class['python'],
 }
 
+python::pip { 'MarkupSafe':
+  ensure => '0.23',
+  require => Class['python'],
+}
+
 wget::fetch { "download latest cloudformation ansible module (bugfix)":
   source => 'https://raw.githubusercontent.com/ansible/ansible-modules-core/e25605cd5bca003a5071aebbdaeb2887e8e5c659/cloud/amazon/cloudformation.py',
   destination => '/usr/local/lib/python2.7/dist-packages/ansible/modules/core/cloud/amazon/cloudformation.py',


### PR DESCRIPTION
Fixes #268