### PR TITLE
Enable full backup support for Jenkins

### DIFF
--- a/nubis/bin/nubis-deploy
+++ b/nubis/bin/nubis-deploy
@@ -15,11 +15,9 @@ VARIABLES=$WORKSPACE/../vars.yaml
 
 FULL_STACK_NAME=$stack_name-$environment
 
-if [ -d artifacts/nubis/terraform ]; then
+if [ -d artifacts/terraform ]; then
   # Verify SSL cert later
   export CONSUL_HTTP_SSL_VERIFY=0
-
-  cd artifacts/nubis/terraform
 
   # Cleanup remote state (make sure doens't leak between environments
   terraform remote config -disable=true
@@ -30,14 +28,15 @@ if [ -d artifacts/nubis/terraform ]; then
     -backend=consul \
     -backend-config="path=deploy/$service_name/$environment/tf-state" \
 
-  terraform get -update=true
+  terraform get -update=true artifacts/terraform
 
   terraform apply \
     -var account=$NUBIS_ACCOUNT \
     -var region=$region \
     -var environment=$environment \
     -var service_name=$service_name \
-    -var ami=$ami
+    -var ami=$ami \
+    artifacts/terraform
 
   terraform remote config -disable=true
   rm -f terraform.tfstate*

--- a/nubis/builder/provisioners.json
+++ b/nubis/builder/provisioners.json
@@ -1,93 +1,108 @@
 {
   "provisioners": [
-   {
-    "type": "shell",
-    "inline" : ["sudo apt-get update"],
-    "order": 5
-  },
-  {
-    "type": "file",
-    "source": "nubis/jenkins/deployment.xml",
-    "destination": "/tmp/jenkins-deployment-config.xml",
-    "order": 21
-  },
-  {
-    "type": "file",
-    "source": "nubis/jenkins/build.xml",
-    "destination": "/tmp/jenkins-build-config.xml",
-    "order": 22
-  },
-  {
-    "type": "file",
-    "source": "nubis/jenkins/build-promotion-deployed.xml",
-    "destination": "/tmp/jenkins-build-promotion-deployed-config.xml",
-    "order": 22
-  },  {
-    "type": "file",
-    "source": "nubis/jenkins/config.xml",
-    "destination": "/tmp/jenkins-config.xml",
-    "order": 23
-  },
-  {
-    "type": "file",
-    "source": "nubis/jenkins/jenkins.model.JenkinsLocationConfiguration.xml",
-    "destination": "/tmp/jenkins-location.xml",
-    "order": 24
-  },
-  {
-    "type": "file",
-    "source": "nubis/jenkins/hudson.plugins.s3.S3BucketPublisher.xml",
-    "destination": "/tmp/jenkins-s3bucketpublisher.xml",
-    "order": 25
-  },  
-  {
-    "type": "file",
-    "source": "nubis/jenkins/proxy.xml",
-    "destination": "/tmp/jenkins-proxy.xml",
-    "order": 25
-  },
-  {
-    "type": "file",
-    "source": "nubis/bin/jenkins-startup.sh",
-    "destination": "/tmp/jenkins-startup.sh",
-    "order": 26
-  },
-  {
-    "type": "file",
-    "source": "nubis/bin/sts",
-    "destination": "/tmp/sts",
-    "order": 27
-  },
-  {
-    "type": "file",
-    "source": "nubis/bin/nubis-deploy",
-    "destination": "/tmp/nubis-deploy",
-    "order": 28
-  },
-  {
-    "type": "shell",
-    "inline": [
-      "mkdir /tmp/confd"
-    ],
-    "order": 28
-  },
-  {
-    "type": "file",
-    "source": "nubis/files/confd/",
-    "destination": "/tmp/confd/",
-    "order": 29
-  },  
-  {
-    "type": "shell",
+    {
+      "type": "shell",
       "inline": [
-	"sudo mv /tmp/jenkins-startup.sh /etc/nubis.d/jenkins",
-	"sudo mv /tmp/confd/*.toml /etc/confd/conf.d/",
-	"sudo mv /tmp/confd/*.tmpl /etc/confd/templates/",
-	"sudo mv /tmp/sts /tmp/nubis-deploy /usr/local/bin/",
-	"sudo chmod 755 /etc/nubis.d/jenkins /usr/local/bin/sts /usr/local/bin/nubis-deploy",
-	"sudo mv /tmp/jenkins-*.xml /etc/nubis.d/"
+        "sudo apt-get update"
       ],
-    "order": 30
-  }
+      "order": 5
+    },
+    {
+      "type": "file",
+      "source": "nubis/jenkins/deployment.xml",
+      "destination": "/tmp/jenkins-deployment-config.xml",
+      "order": 21
+    },
+    {
+      "type": "file",
+      "source": "nubis/jenkins/build.xml",
+      "destination": "/tmp/jenkins-build-config.xml",
+      "order": 22
+    },
+    {
+      "type": "file",
+      "source": "nubis/jenkins/build-promotion-deployed.xml",
+      "destination": "/tmp/jenkins-build-promotion-deployed-config.xml",
+      "order": 22
+    },
+    {
+      "type": "file",
+      "source": "nubis/jenkins/config.xml",
+      "destination": "/tmp/jenkins-config.xml",
+      "order": 23
+    },
+    {
+      "type": "file",
+      "source": "nubis/jenkins/jenkins.model.JenkinsLocationConfiguration.xml",
+      "destination": "/tmp/jenkins-location.xml",
+      "order": 24
+    },
+    {
+      "type": "file",
+      "source": "nubis/jenkins/hudson.plugins.s3.S3BucketPublisher.xml",
+      "destination": "/tmp/jenkins-s3bucketpublisher.xml",
+      "order": 25
+    },
+    {
+      "type": "file",
+      "source": "nubis/jenkins/thinBackup.xml",
+      "destination": "/tmp/jenkins-thinBackup.xml",
+      "order": 25
+    },
+    {
+      "type": "file",
+      "source": "nubis/jenkins/org.jenkinsci.main.modules.sshd.SSHD.xml",
+      "destination": "/tmp/jenkins-ssh.xml",
+      "order": 25
+    },
+    {
+      "type": "file",
+      "source": "nubis/jenkins/proxy.xml",
+      "destination": "/tmp/jenkins-proxy.xml",
+      "order": 25
+    },
+    {
+      "type": "file",
+      "source": "nubis/bin/jenkins-startup.sh",
+      "destination": "/tmp/jenkins-startup.sh",
+      "order": 26
+    },
+    {
+      "type": "file",
+      "source": "nubis/bin/sts",
+      "destination": "/tmp/sts",
+      "order": 27
+    },
+    {
+      "type": "file",
+      "source": "nubis/bin/nubis-deploy",
+      "destination": "/tmp/nubis-deploy",
+      "order": 28
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "mkdir /tmp/confd"
+      ],
+      "order": 28
+    },
+    {
+      "type": "file",
+      "source": "nubis/files/confd/",
+      "destination": "/tmp/confd/",
+      "order": 29
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo mv /tmp/jenkins-startup.sh /etc/nubis.d/jenkins",
+        "sudo mv /tmp/confd/*.toml /etc/confd/conf.d/",
+        "sudo mv /tmp/confd/*.tmpl /etc/confd/templates/",
+        "sudo mv /tmp/sts /tmp/nubis-deploy /usr/local/bin/",
+        "sudo chmod 755 /etc/nubis.d/jenkins /usr/local/bin/sts /usr/local/bin/nubis-deploy",
+        "sudo mv /tmp/jenkins-*.xml /etc/nubis.d/"
+      ],
+      "order": 30
+    }
   ]
 }

--- a/nubis/jenkins/build.xml
+++ b/nubis/jenkins/build.xml
@@ -75,14 +75,15 @@ if [ -d nubis/terraform ]; then
   rsync -av nubis/terraform artifacts/
 fi
 if [ -d nubis/builder/artifacts ]; then
-  rsync -av nubis/builder/artifacts/ artifacts/
+  mkdir -p artifacts/builder/
+  rsync -av nubis/builder/artifacts/ artifacts/builder/
 fi
 </command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>artifacts/*</artifacts>
+      <artifacts>artifacts/**</artifacts>
       <allowEmptyArchive>false</allowEmptyArchive>
       <onlyIfSuccessful>false</onlyIfSuccessful>
       <fingerprint>true</fingerprint>

--- a/nubis/jenkins/org.jenkinsci.main.modules.sshd.SSHD.xml
+++ b/nubis/jenkins/org.jenkinsci.main.modules.sshd.SSHD.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<org.jenkinsci.main.modules.sshd.SSHD>
+  <port>-1</port>
+</org.jenkinsci.main.modules.sshd.SSHD>

--- a/nubis/jenkins/thinBackup.xml
+++ b/nubis/jenkins/thinBackup.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<org.jvnet.hudson.plugins.thinbackup.ThinBackupPluginImpl plugin="thinBackup@1.7.4">
+  <fullBackupSchedule>H H * * *</fullBackupSchedule>
+  <diffBackupSchedule>H/15 * * * *</diffBackupSchedule>
+  <backupPath>/mnt/jenkins</backupPath>
+  <nrMaxStoredFull>14</nrMaxStoredFull>
+  <excludedFilesRegex></excludedFilesRegex>
+  <waitForIdle>true</waitForIdle>
+  <forceQuietModeTimeout>120</forceQuietModeTimeout>
+  <cleanupDiff>true</cleanupDiff>
+  <moveOldBackupsToZipFile>true</moveOldBackupsToZipFile>
+  <backupBuildResults>true</backupBuildResults>
+  <backupBuildArchive>true</backupBuildArchive>
+  <backupUserContents>true</backupUserContents>
+  <backupNextBuildNumber>true</backupNextBuildNumber>
+  <backupBuildsToKeepOnly>false</backupBuildsToKeepOnly>
+</org.jvnet.hudson.plugins.thinbackup.ThinBackupPluginImpl>


### PR DESCRIPTION
Is implemented like so:
 - thinBackup plugin backs up to /mnt/jenkins on an interval
 - cron job pushes/sync /mnt/jenkins to the CI bucket on S3
 - bootup:
   - startup script pulls from CI bucket on S3
   - startup script manually restores Jenkins before starting it

Fixes #145
Fixes #96