### PR TITLE
Bump maximum header size to 16K

### DIFF
--- a/nubis/puppet/jenkins.pp
+++ b/nubis/puppet/jenkins.pp
@@ -18,7 +18,7 @@ class { 'jenkins':
   service_ensure     => 'stopped',
   config_hash        => {
     'JENKINS_ARGS' => {
-      'value' => '--webroot=/var/cache/$NAME/war --httpPort=$HTTP_PORT --prefix=$PREFIX'
+      'value' => '--webroot=/var/cache/$NAME/war --httpPort=$HTTP_PORT --prefix=$PREFIX --requestHeaderSize=16384'
     },
     'JAVA_ARGS'    => {
       'value' => '-Djava.awt.headless=true -Dhudson.diyChunking=false -Dhttp.proxyHost=proxy.service.consul -Dhttp.proxyPort=3128 -Dhttps.proxyHost=proxy.service.consul -Dhttps.proxyPort=3128'


### PR DESCRIPTION
Necessary because mod_auth_openidc passes in a group list that can be quite large

Fixes #468