### PR TITLE
Keep our builds from growing unbounded

### DIFF
--- a/nubis/files/seed.xml
+++ b/nubis/files/seed.xml
@@ -127,6 +127,7 @@ sites.each {
             }
             branch(&apos;master&apos;)
         extensions {
+          cleanBeforeCheckout()
           submoduleOption {
             disableSubmodules(false)
             recursiveSubmodules(true)
@@ -140,6 +141,20 @@ sites.each {
     }
 
     publishers {
+          discardBuildPublisher {
+		daysToKeep(&quot;14&quot;)
+		intervalDaysToKeep(&quot;&quot;)
+		numToKeep(&quot;250&quot;)
+		intervalNumToKeep(&quot;&quot;)
+		discardSuccess(false)
+		discardUnstable(false)
+		discardFailure(false)
+		discardNotBuilt(false)
+		discardAborted(false)
+		minLogFileSize(&quot;&quot;)
+		maxLogFileSize(&quot;&quot;)
+		regexp(&quot;&quot;)
+        }
         mailer(&apos;infra-aws@mozilla.com&apos;, true, true)
         slackNotifier {
           notifyAborted(true)
@@ -201,6 +216,7 @@ sites.each {
             }
             branch(&apos;master&apos;)
         extensions {
+          cleanBeforeCheckout()
           submoduleOption {
             disableSubmodules(false)
             recursiveSubmodules(true)
@@ -224,6 +240,21 @@ sites.each {
     }
 
     publishers {
+          discardBuildPublisher {
+		daysToKeep(&quot;14&quot;)
+		intervalDaysToKeep(&quot;&quot;)
+		numToKeep(&quot;250&quot;)
+		intervalNumToKeep(&quot;&quot;)
+		discardSuccess(false)
+		discardUnstable(false)
+		discardFailure(false)
+		discardNotBuilt(false)
+		discardAborted(false)
+		minLogFileSize(&quot;&quot;)
+		maxLogFileSize(&quot;&quot;)
+		regexp(&quot;&quot;)
+        }
+
         archiveArtifacts(&apos;artifacts/**&apos;)
         downstreamParameterized {
             trigger(&quot;${site_name}-deployment&quot;) {

--- a/nubis/puppet/jenkins-plugins.pp
+++ b/nubis/puppet/jenkins-plugins.pp
@@ -48,6 +48,10 @@ jenkins::plugin { 'copyartifact':
   version => '1.39'
 }
 
+jenkins::plugin { 'discard-old-build':
+  version => '1.05'
+}
+
 jenkins::plugin { 'display-url-api':
   version => '2.2.0'
 }


### PR DESCRIPTION
- Use Discard Old Build plugin to keep only
  - 30 days of builds
  - 250 builds

 - Also, clean our workspace *before* every build, to keep generated
   artifacts from balooning

Fixes #531