### PR TITLE
Increase ELB initial grace period to 30 minutes

### DIFF
--- a/nubis/terraform/main.tf
+++ b/nubis/terraform/main.tf
@@ -131,7 +131,7 @@ resource "aws_autoscaling_group" "ci" {
 
   max_size                  = "2"
   min_size                  = "0"
-  health_check_grace_period = 600
+  health_check_grace_period = 1800
   health_check_type         = "ELB"
   desired_capacity          = "1"
   force_delete              = true


### PR DESCRIPTION
Jenkins starts up slow, especially when recovering from backups

Fixes #602