### PR TITLE
Allow ability to skip a packer build

### DIFF
--- a/nubis/files/nubis-ci-build
+++ b/nubis/files/nubis-ci-build
@@ -2,11 +2,17 @@
 
 set -e
 
+rm -rf artifacts
+mkdir artifacts
+
 SKIP_BUILD=$(jq -rM '.variables.skip_build' nubis/builder/project.json)
 
 # If there is a deploy_only variable don't do a build
 if [ "${SKIP_BUILD}" == "true" ]; then
     echo "Skipping build"
+    # jenkins gets grumpy if artifacts folder is empty
+    # so we just add something here
+    touch "artifacts/SKIP"
     exit 0
 fi
 
@@ -22,9 +28,6 @@ consulate kv set "nat/$NUBIS_ARENA/config/IptablesAllowTCP" "$NEW_ALLOWED_TCP"
 nubis-builder build --instance-type c3.large --spot
 
 consulate kv set "nat/$NUBIS_ARENA/config/IptablesAllowTCP" "$ORIG_ALLOWED_TCP"
-
-rm -rf artifacts
-mkdir artifacts
 
 if [ -d nubis/terraform ]; then
   rsync -av nubis/terraform artifacts/

--- a/nubis/files/nubis-ci-build
+++ b/nubis/files/nubis-ci-build
@@ -2,6 +2,14 @@
 
 set -e
 
+SKIP_BUILD=$(jq -rM '.variables.skip_build' nubis/builder/project.json)
+
+# If there is a deploy_only variable don't do a build
+if [ "${SKIP_BUILD}" == "true" ]; then
+    echo "Skipping build"
+    exit 0
+fi
+
 NUBIS_ARENA=$(nubis-metadata NUBIS_ARENA)
 
 ORIG_ALLOWED_TCP=$(consul kv get "nat/$NUBIS_ARENA/config/IptablesAllowTCP" 2>/dev/null || echo '[]')

--- a/nubis/files/nubis-ci-deploy
+++ b/nubis/files/nubis-ci-deploy
@@ -7,6 +7,9 @@ declare environment
 declare service_name
 declare TF_CONSUL_WORKAROUND
 
+# We are skipping builds
+SKIP_BUILD=$(jq -rM '.variables.skip_build' nubis/builder/project.json)
+
 cleanup () {
   if [ ! -z "$TF_CONSUL_WORKAROUND" ]; then
     rm -f "$TF_CONSUL_WORKAROUND" 2>/dev/null
@@ -36,7 +39,13 @@ else
   exit 1
 fi
 
-echo "Deploying AMI $ami into $environment/$region ($action)"
+if [ "${SKIP_BUILD}" == "true" ]; then
+    echo "Deploying into $environment/$region ($action)"
+    terraform_ami_arg=""
+else
+    echo "Deploying AMI $ami into $environment/$region ($action)"
+    terraform_ami_arg="-var ami=\"$ami\""
+fi
 
 VARIABLES=$WORKSPACE/../vars.tfvars
 
@@ -68,7 +77,7 @@ if [ -d artifacts/terraform ]; then
     -var region="$region" \
     -var environment="$environment" \
     -var service_name="$service_name" \
-    -var ami="$ami" \
+    $terraform_ami_arg \
     $terraform_extra_args \
     artifacts/terraform
 

--- a/nubis/files/nubis-ci-deploy
+++ b/nubis/files/nubis-ci-deploy
@@ -5,6 +5,7 @@ set -e
 declare region
 declare environment
 declare service_name
+declare -a terraform_ami_arg
 declare TF_CONSUL_WORKAROUND
 
 # We are skipping builds
@@ -41,10 +42,10 @@ fi
 
 if [ "${SKIP_BUILD}" == "true" ]; then
     echo "Deploying into $environment/$region ($action)"
-    terraform_ami_arg=""
+    terraform_ami_arg=()
 else
     echo "Deploying AMI $ami into $environment/$region ($action)"
-    terraform_ami_arg="-var ami=\"$ami\""
+    terraform_ami_arg=( -var "ami=$ami" )
 fi
 
 VARIABLES=$WORKSPACE/../vars.tfvars
@@ -77,7 +78,7 @@ if [ -d artifacts/terraform ]; then
     -var region="$region" \
     -var environment="$environment" \
     -var service_name="$service_name" \
-    $terraform_ami_arg \
+    "${terraform_ami_arg[@]}" \
     $terraform_extra_args \
     artifacts/terraform
 

--- a/nubis/files/nubis-ci-deploy
+++ b/nubis/files/nubis-ci-deploy
@@ -20,7 +20,7 @@ trap cleanup EXIT
 # Consume user-data
 eval "$(nubis-metadata)"
 
-if [ "$ami" = "" ]; then
+if [ "$ami" = "" ] && [ "${SKIP_BUILD}" != "true" ]; then
   # shellcheck disable=SC2016
   ami=$(jq -r '.last_run_uuid as $uuid | .builds[] | select (.packer_run_uuid == $uuid) .artifact_id' artifacts/builder/AMIs.json | sed -e's/,/\n/g' | grep "$region:" | cut -d: -f2)
 fi


### PR DESCRIPTION
We can now skip packer builds and just go straight to a terraform deploy.

Fixes #625